### PR TITLE
added detail to a few steps and changed picture in 1.8

### DIFF
--- a/LabGuides/Lab9-NsxtPipelineInstall/readme.md
+++ b/LabGuides/Lab9-NsxtPipelineInstall/readme.md
@@ -66,7 +66,7 @@ Concourse can be stoodup in many different ways. In this lab we will stand it up
 <img src="Images/concourse-login.png">
 </details>
 
-1.6 Import the NSX pipeline using the `fly` cli command on the cli-vm.
+1.6 Import the NSX pipeline using the `fly` cli command on the cli-vm.  The source script will create the `fly-s` alias used below to simplify the commands.
 
 `cd ~/nsx-t-datacenter-ci-pipelines/pipelines`
 
@@ -91,19 +91,19 @@ Concourse can be stoodup in many different ways. In this lab we will stand it up
 <img src="Images/confirm-import.png">
 </details>
 
-1.7 Go back to the web browser and confirm that the pipeline has imported and hit the **Play** button
+1.7 Go back to the web browser and confirm that the pipeline has imported and hit the **Play** button in the lower right hand corner of the *install-nsx-t* tile
 
 <details><summary>Screenshot 1.7</summary>
 <img src="Images/pipeline-ui.png">
 </details>
 
-1.8 Click on *install-nsx-t* 
+1.8 Click on *install-nsx-t*
 
 <details><summary>Screenshot 1.8</summary>
-<img src="Images/pipeline-ui.png">
+<img src="Images/install-nsx-t.png">
 </details>
 
-1.9 Verify that the pipeline is not in an *errored* state.
+1.9 Verify that the pipeline is not in an *errored* state
 
 - You will see Maroon colored boxes if the pipline is errored out
   - If it is in an errored state perform a `fly-d` and `fly-s` to destory and re-import the pipeline on the cli-vm.
@@ -112,7 +112,7 @@ Concourse can be stoodup in many different ways. In this lab we will stand it up
 <img src="Images/pipeline-started.png">
 </details>
 
-1.10 Click on the **install-nsx-t**
+1.10 Click on the **install-nsx-t** light-gray box in the pipeline
 
 <details><summary>Screenshot 1.10</summary>
 <img src="Images/install-nsx-t.png">
@@ -124,7 +124,7 @@ Concourse can be stoodup in many different ways. In this lab we will stand it up
 <img src="Images/install-nsx-t-plus.png">
 </details>
 
-1.12 Grab some coffee and watch the magic happen! 
+1.12 Grab some coffee and watch the magic happen!
 
 <img src="Images/automate-all-things.png">
 


### PR DESCRIPTION
Worked on Lab 9 Guide and added a little detail to certain steps.  Also, changed the image in 1.8 to reflect what would show after you clicked *install-nsx-t* the first time in Concourse.