### PR TITLE
correct username / pwd for concourse

### DIFF
--- a/LabGuides/NsxtPipelineInstall-IN7016/readme.md
+++ b/LabGuides/NsxtPipelineInstall-IN7016/readme.md
@@ -90,8 +90,8 @@ Concourse can be stoodup in many different ways. In this lab we will stand it up
 
 1.6 In the upper right-hand corner login to Concourse
 
-- Username: admin
-- Password: VMware1!
+- Username: nsx
+- Password: vmware
 
 <details><summary>Screenshot 1.6</summary>
 <img src="Images/concourse-login.png">


### PR DESCRIPTION
typo in guide with regard to correct username and password to login to concourse web ui to start NSX-T pipeline.