### PR TITLE
Service Network Network Assignment

### DIFF
--- a/LabGuides/PksInstallPhase2-IN1916/readme.md
+++ b/LabGuides/PksInstallPhase2-IN1916/readme.md
@@ -21,7 +21,7 @@
 - Place singleton jobs in : PKS-MGMT-1
 - Balance other jobs in: PKS-MGMT-1
 - Network: PKS-MGMT
-- Service Network: PKS-COMP
+- Service Network: PKS-MGMT
 - Click `Save`
 
 <details><summary>Screenshot 1.3</summary><img src="Images/2019-01-06-17-31-07.png"></details><br>


### PR DESCRIPTION
ideally , we would not have defined the ls-pks-service network in the bosh tile and here we would just point to PKS-MGMT as a placeholder since that setting has no effect but an input is required...
This pullrequest should aliogn with the pull request made on the first lab guide part 1 where in bosh we do not create the ls-pks-service network