### PR TITLE
need gw ip reserved in reserved ips field

### DIFF
--- a/LabGuides/PksInstallPhase1-IN3138/readme.md
+++ b/LabGuides/PksInstallPhase1-IN3138/readme.md
@@ -255,7 +255,7 @@ _Note: Each of the availability zones below will have a single cluster. When you
   - Name: `PKS-MGMT`
   - vSphere Network Name: `ls-pks-mgmt`
   - CIDR: `172.31.0.0/24`
-  - Reserved IP Ranges: `172.31.0.3`
+  - Reserved IP Ranges: `172.31.0.1,172.31.0.3`
   - DNS: `192.168.110.10`
   - Gateway: `172.31.0.1`
   - Availability Zones: `PKS-MGMT-1`


### PR DESCRIPTION
just like what is done for PKS-COMP network where GW is part of reserved range.
Plus pivotal doc also shows that gw ip is to be in that reserved range...
Might not matter in this lab but only because bosh does not consume the ip... maybe you don't need it cause it auto adds the gw address as a reserved one in the backend but i'd go with what the pivotal guide shows...