### PR TITLE
service network in PKS-MGMT bosh network

### DIFF
--- a/LabGuides/PksInstallPhase2-IN1916/readme.md
+++ b/LabGuides/PksInstallPhase2-IN1916/readme.md
@@ -21,7 +21,7 @@
 - Place singleton jobs in : PKS-MGMT-1
 - Balance other jobs in: PKS-MGMT-1
 - Network: PKS-MGMT
-- Service Network: PKS-COMP
+- Service Network: PKS-MGMT
 - Click `Save`
 
 <details><summary>Screenshot 1.3</summary><img src="Images/2019-01-06-17-31-07.png"></details><br>


### PR DESCRIPTION
this change is to be made when decided to not create a PKS-COMP network in bosh (wherein the ls-pks-service network is specified. Not needed as indicated in corresponding pull request since NSXT will create that itself).
just point to PKS-MGMT as one needs to make a selection.
pp176 of pivotal guide:
"if you are deploying PKS with NSX-T for the first time, the "Service Network"  field does not apply because PKS creates the service network for you during the installation process. However, the PKS tile requires you to make a selection. Therefore select the same network you specified in the 'Network' field.