### PR TITLE
Fixed typo in Velero LabGuide title

### DIFF
--- a/LabGuides/PKSBackupVelero-PV3774/readme.md
+++ b/LabGuides/PKSBackupVelero-PV3774/readme.md
@@ -1,4 +1,4 @@
-# PKS Backup and Restore using VMWare Heptio Velero
+# PKS Backup and Restore using VMware Heptio Velero
 
 ## Overview
 


### PR DESCRIPTION
Changed "VMWare" to "VMware" in labguide title.