### PR TITLE
minor typo

### DIFF
--- a/LabGuides/IntroToHelm-HE4490/readme.md
+++ b/LabGuides/IntroToHelm-HE4490/readme.md
@@ -231,7 +231,7 @@ kubectl proxy
 </details>
 <br/>
 
-2.1.9 From the Main Console (ControlCenter) desktop, open a chrome browser session and on the shortcuts bar select the shortcut `Sign in - Kubernetes` to access your kubernetes dashboard and proceed through the following steps to sign in:
+2.1.9 From the Main Console (ControlCenter) desktop, open a chrome browser session and on the shortcuts bar select the shortcut `Kubernetes Dashboard` to access your kubernetes dashboard and proceed through the following steps to sign in:
 
 - Select `Kubeconfig`
 - Click on `Choose kubeconfig file`


### PR DESCRIPTION
Changed `Sign in - Kubernetes` to `Kubernetes Dashboard` to reflect accurate bookmark name. (Using Baseline v12 template, FYI)